### PR TITLE
Fixed issue where duplicate JavaScript is being merged into a single …

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -16,7 +16,8 @@ var src = {
     css: './GrowCreate.PipelineCRM/App_Plugins/PipelineCRM/css/pipeline.css',
     scripts: [
         './GrowCreate.PipelineCRM/App_Plugins/**/*.js',
-        '!./GrowCreate.PipelineCRM/App_Plugins/PipelineCRM/pipeline.min.js',
+        '!./GrowCreate.PipelineCRM/App_Plugins/PipelineCRM/pipeline.js',
+        '!./GrowCreate.PipelineCRM/App_Plugins/PipelineCRM/pipeline.min.js'
     ],
     appPlugins: [ // Needs to be like this until I can include everything but not .js files (but still .min.js).
         './GrowCreate.PipelineCRM/App_Plugins/**/*.html',


### PR DESCRIPTION
Fixed issue where duplicate JavaScript is being merged into a single JavaScript file by the gulp 'scripts' task.

Hi,

I noticed an issue with the 'scripts' gulp task in that it was merging all JS files into one, including the pipeline.js file, which already seemed to contain the combined contents of the other 4 JavaScript files in there:

- pipeline.controller.js
- pipeline.directives.js
- pipeline.filters.js
- pipeline.resource.js

I have added an additional ignore rule to exclude the pipeline.js file from this task, so that only the 4 JavaScript files listed above are included within the merged file.