### PR TITLE
Fixes issues where tasks were not being displayed.

### DIFF
--- a/GrowCreate.PipelineCRM/App_Plugins/PipelineCRM/backoffice/pipelineCrmTree/tasks.html
+++ b/GrowCreate.PipelineCRM/App_Plugins/PipelineCRM/backoffice/pipelineCrmTree/tasks.html
@@ -6,7 +6,7 @@
     </umb-header>
     <umb-tab-view>
         <div ng-controller="Pipeline.Dashboards.Tasks" class="pipeline">
-            <pipeline-timeline tasks="tasks" parent-type="'user'" parent="user"></pipeline-timeline>
+            <pipeline-timeline ng-if="loaded" tasks="tasks" parent-type="'user'" parent="user"></pipeline-timeline>
         </div>
     </umb-tab-view>
 </umb-panel>


### PR DESCRIPTION
Tasks do not display within the Pipeline CRM.

Retrieving the data with AJAX appears to load the directive _before_ the data is obtained. Therefore, the `tasks` are not available in the directive `$scope`.

Adding **ng-if="loaded"** ensures that directive only displays data once it has successfully been loaded.