### PR TITLE
Fixes issue where running "gulp pack" was not generating the nuget package

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -25,7 +25,7 @@ gulp.task('pack-pipeline', function() {
 				.on('end', resolve);
 		}),
 	]).then(function() {
-		exec('nuget pack Nuget\Package.nuspec -verbose', function(error, stdout, stderr) {
+		exec('nuget pack Nuget/Package.nuspec -verbosity detailed', function(error, stdout, stderr) {
 			console.log(stdout);
 		});
 	});


### PR DESCRIPTION
I have tried to run the following to create the NuGet package, but it didn't seem to create the package at all:

```
gulp pack
```

It seems the version of Nuget (3.5.0.1938) I am using (and I assume others will be too as v3.5 is the current recommended version) has deprecated the `-verbose` option in favour of `-verbosity`.  See the **Note** on [https://docs.microsoft.com/en-us/nuget/tools/nuget-exe-cli-reference](https://docs.microsoft.com/en-us/nuget/tools/nuget-exe-cli-reference)

Also, I had to change the `nuget pack` command as it didn't seem to locate the `Package.nuspec` file correctly as I seemed to get the following error: 

```
System.IO.FileNotFoundException: Could not find file 'E:\dev\PipelineCRM\NugetPackage.nuspec'.
```

Basically, on line 28 of the `gulpfile.js` file, I have changed it from:

```
exec('nuget pack Nuget\Package.nuspec -verbose', function(error, stdout, stderr) {
```

to

```
exec('nuget pack Nuget/Package.nuspec -verbosity detailed', function(error, stdout, stderr) {
```

These changes now allow me to run `gulp pack` which now generates the relevant Nuget package successfully.